### PR TITLE
Allow optional fields in `object`

### DIFF
--- a/spec/index-spec.ts
+++ b/spec/index-spec.ts
@@ -148,9 +148,22 @@ describe('object', () => {
       )
       expect(decoder.decodeJSON('{"x":3,"y":4}')).toEqual([3, 4])
     })
+
+    it('can decode an object with optional keys', () => {
+      interface User {
+        name?: string
+      }
+
+      const decoder: module.Decoder<User> = module.object(
+        ['name', module.oneOf(module.string(), module.succeed(undefined))],
+        (name) => ({name})
+      )
+
+      expect(decoder.decodeJSON(`{}`)).toEqual({name: undefined})
+    })
   })
 
-  describe('when incorrect JSON', () => {
+  describe('when given incorrect JSON', () => {
     it('fails when not given an object', () => {
       const decoder = module.object(
         ['x', module.number()],
@@ -175,7 +188,7 @@ describe('object', () => {
       const decoder = module.object(
         ['x', module.number()],
         ['y', module.number()],
-        ['?', module.succeed('????')],
+        ['?', module.string()],
         (x: number, y: number, huh: string) => ({x, y, huh})
       )
       expect(() => decoder.decodeJSON('{"x": 5}')).toThrowError(

--- a/src/index.ts
+++ b/src/index.ts
@@ -255,11 +255,19 @@ export function object <T>(...args: any[]): Decoder<T> {
     }
 
     decoders.forEach(([key, decoder]) => {
-      if (key in obj) {
-        values.push(decode(decoder, obj[key], pushLocation(at, key)))
-      } else {
-        missingKeys.push(key)
+      let value
+
+      try {
+        value = decode(decoder, obj[key], pushLocation(at, key))
+      } catch (err) {
+        if (!(key in obj)) {
+          missingKeys.push(key)
+        } else {
+          throw err
+        }
       }
+
+      values.push(value)
     })
 
     if (missingKeys.length > 0) {


### PR DESCRIPTION
This commit allows `object` to decode objects with optional fields.

`object` now passes `undefined` to the decoder if the key is not in the object. This combined with `oneOf` and `succeed` can be used to decode optional fields. See the added test for exact usage.