### PR TITLE
Migrate typings to @types

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,8 @@
   "version": "0.2.0",
   "description": "Elm-inspired JSON decoder for typescript",
   "main": "src/index.js",
-  "typings": "src/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && tsc && rm -r dist/spec && cp README.md LICENSE package.json dist",
-    "typings": "typings install",
     "test": "tsc && node util/test.js",
     "docs": "typedoc --out docs --excludeNotExported --excludePrivate src"
   },
@@ -28,9 +26,9 @@
   },
   "homepage": "https://github.com/ooesili/type-safe-json-decoder#readme",
   "devDependencies": {
+    "@types/jasmine": "^2.5.53",
     "jasmine": "^2.5.2",
     "typedoc": "^0.5.0",
-    "typescript": "^2.0.3",
-    "typings": "^1.4.0"
+    "typescript": "^2.0.3"
   }
 }

--- a/typings.json
+++ b/typings.json
@@ -1,7 +1,0 @@
-{
-  "name": "type-safe-json-decoder",
-  "dependencies": {},
-  "globalDependencies": {
-    "jasmine": "registry:dt/jasmine#2.5.0+20161003201800"
-  }
-}

--- a/wercker.yml
+++ b/wercker.yml
@@ -3,9 +3,6 @@ box: node
 dev:
   steps:
   - npm-install
-  - script: &typings
-      name: typings install
-      code: npm run typings
   - internal/watch:
       code: npm test
       reload: true
@@ -13,7 +10,6 @@ dev:
 build:
   steps:
   - npm-install
-  - script: *typings
   - npm-test
 
 docs:


### PR DESCRIPTION
Since TypeScript 2.0 type declaration files can be installed via the `@types` npm namespace.
https://blogs.msdn.microsoft.com/typescript/2016/06/15/the-future-of-declaration-files/