### PR TITLE
Add Intersection method

### DIFF
--- a/spec/index-spec.ts
+++ b/spec/index-spec.ts
@@ -518,6 +518,22 @@ describe('union', () => {
   })
 })
 
+describe('intersection', () => {
+  describe('decoding an intersection of string properties', () => {
+    type PartA = { propA: string }
+    type PartB = { propB: string }
+    type Parts = PartA & PartB
+    const decoder: module.Decoder<Parts> = module.intersect(
+      module.object(["propA", module.string()], (propA): PartA => ({ propA })),
+      module.object(["propB", module.string()], (propB): PartB => ({ propB }))
+    )
+
+    it('can decode valid object', () => {
+      expect(decoder.decodeJSON(`{"propA":"foo","propB":"bar"}`)).toEqual({ propA: 'foo', propB: 'bar' })
+    })
+  })
+})
+
 describe('lazy', () => {
   describe('decoding a primitive data type', () => {
     const decoder = module.lazy(() => module.string())

--- a/spec/index-spec.ts
+++ b/spec/index-spec.ts
@@ -531,6 +531,12 @@ describe('intersection', () => {
     it('can decode valid object', () => {
       expect(decoder.decodeJSON(`{"propA":"foo","propB":"bar"}`)).toEqual({ propA: 'foo', propB: 'bar' })
     })
+    
+    it('fails to decode if field missing', () => {
+      expect(() => decoder.decodeJSON(`{"propA":"foo"}`)).toThrowError(
+        `error at root: expected object with keys: propB`
+      )
+    })
   })
 })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -478,6 +478,39 @@ export function union (...decoders: Decoder<any>[]): Decoder<any> {
 }
 
 /**
+ * Decode a intersection type. Given multiple decoders whose result type is a member
+ * of the intersection, execute each one in order and intersect the fields into a single type.
+ * @param ad A decoder for a member of the intersection.
+ * @param bd A decoder for another member of the intersection.
+ * @returns A decoder or throws an Error of any decoder fails.
+ */
+
+export function intersect <A, B>(ad: Decoder<A>, bd: Decoder<B>): Decoder<A & B>
+export function intersect <A, B, C>(ad: Decoder<A>, bd: Decoder<B>, cd: Decoder<C>): Decoder<A & B & C>
+export function intersect <A, B, C, D>(ad: Decoder<A>, bd: Decoder<B>, cd: Decoder<C>, dd: Decoder<D>): Decoder<A & B & C & D>
+export function intersect <A, B, C, D, E>(ad: Decoder<A>, bd: Decoder<B>, cd: Decoder<C>, dd: Decoder<D>, ed: Decoder<E>): Decoder<A & B & C & D & E>
+export function intersect <A, B, C, D, E, F>(ad: Decoder<A>, bd: Decoder<B>, cd: Decoder<C>, dd: Decoder<D>, ed: Decoder<E>, fd: Decoder<F>): Decoder<A & B & C & D & E & F>
+export function intersect <A, B, C, D, E, F, G>(ad: Decoder<A>, bd: Decoder<B>, cd: Decoder<C>, dd: Decoder<D>, ed: Decoder<E>, fd: Decoder<F>, gd: Decoder<G>): Decoder<A & B & C & D & E & F & G>
+export function intersect <A, B, C, D, E, F, G, H>(ad: Decoder<A>, bd: Decoder<B>, cd: Decoder<C>, dd: Decoder<D>, ed: Decoder<E>, fd: Decoder<F>, gd: Decoder<G>, hd: Decoder<H>): Decoder<A & B & C & D & E & F & G & H>
+export function intersect <A, B, C, D, E, F, G, H, I>(ad: Decoder<A>, bd: Decoder<B>, cd: Decoder<C>, dd: Decoder<D>, ed: Decoder<E>, fd: Decoder<F>, gd: Decoder<G>, hd: Decoder<H>, id: Decoder<I>): Decoder<A & B & C & D & E & F & G & H & I>
+export function intersect <A, B, C, D, E, F, G, H, I, J>(ad: Decoder<A>, bd: Decoder<B>, cd: Decoder<C>, dd: Decoder<D>, ed: Decoder<E>, fd: Decoder<F>, gd: Decoder<G>, hd: Decoder<H>, id: Decoder<I>, jd: Decoder<J>): Decoder<A & B & C & D & E & F & G & H & I & J>
+export function intersect <A, B, C, D, E, F, G, H, I, J, K>(ad: Decoder<A>, bd: Decoder<B>, cd: Decoder<C>, dd: Decoder<D>, ed: Decoder<E>, fd: Decoder<F>, gd: Decoder<G>, hd: Decoder<H>, id: Decoder<I>, jd: Decoder<J>, kd: Decoder<K>): Decoder<A & B & C & D & E & F & G & H & I & J & K>
+export function intersect <A, B, C, D, E, F, G, H, I, J, K, L>(ad: Decoder<A>, bd: Decoder<B>, cd: Decoder<C>, dd: Decoder<D>, ed: Decoder<E>, fd: Decoder<F>, gd: Decoder<G>, hd: Decoder<H>, id: Decoder<I>, jd: Decoder<J>, kd: Decoder<K>, ld: Decoder<L>): Decoder<A & B & C & D & E & F & G & H & I & J & K & L>
+export function intersect <A, B, C, D, E, F, G, H, I, J, K, L, M>(ad: Decoder<A>, bd: Decoder<B>, cd: Decoder<C>, dd: Decoder<D>, ed: Decoder<E>, fd: Decoder<F>, gd: Decoder<G>, hd: Decoder<H>, id: Decoder<I>, jd: Decoder<J>, kd: Decoder<K>, ld: Decoder<L>, md: Decoder<M>): Decoder<A & B & C & D & E & F & G & H & I & J & K & L & M>
+export function intersect <A, B, C, D, E, F, G, H, I, J, K, L, M, N>(ad: Decoder<A>, bd: Decoder<B>, cd: Decoder<C>, dd: Decoder<D>, ed: Decoder<E>, fd: Decoder<F>, gd: Decoder<G>, hd: Decoder<H>, id: Decoder<I>, jd: Decoder<J>, kd: Decoder<K>, ld: Decoder<L>, md: Decoder<M>, nd: Decoder<N>): Decoder<A & B & C & D & E & F & G & H & I & J & K & L & M & N>
+export function intersect(...decoders: Decoder<any>[]) {
+  return createDecoder((obj, at) => {
+    const result: any = {};
+    for(const decoder of decoders) {
+      const partial = decode(decoder, obj, at)
+      Object.keys(partial).forEach((key) => {
+        result[key] = partial[key]
+      })
+    }
+  })
+}
+
+/**
  * Decode a value with the decoder returned by the given function. This is
  * useful if you need to decode a recursive data structure. TypeScript does not
  * allow the direct use of variables within their definition:

--- a/src/index.ts
+++ b/src/index.ts
@@ -507,6 +507,7 @@ export function intersect(...decoders: Decoder<any>[]) {
         result[key] = partial[key]
       })
     }
+    return result
   })
 }
 


### PR DESCRIPTION
This should get a basic version of intersection types working - helpful when dealing with lots of fields etc.

- Added same overload options as for `union`.
- Added specs to cover success and error conditions.